### PR TITLE
More updates to PR 4110

### DIFF
--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.1
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.1
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-326-g338b9b5d61)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -43,9 +43,7 @@ pair_style      uf3 2
 pair_coeff      1 1 W_W.uf3
 UF3: W_W.uf3 file should contain UF3 potential for 1 1
 UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform
-              knot spacing
-
+UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacing
 
 # # ============= Setup output
 
@@ -64,6 +62,7 @@ velocity        all create 300.0 2367804 loop geom
 fix             1 all nve
 run             ${nsteps}
 run             100
+Generated 0 of 0 mixed pair_coeff terms from geometric mixing rule
 Neighbor list info ...
   update: every = 1 steps, delay = 0 steps, check = yes
   max neighbors/atom: 2000, page size: 100000
@@ -89,20 +88,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.113 | 3.113 | 3.113 Mbytes
         80   173.31044     -4.893466       0             -4.8712389     -397601.62    
         90   150.12364     -4.8904922      0             -4.8712388     -397739.2     
        100   128.38807     -4.8877046      0             -4.8712388     -397980.01    
-Loop time of 0.0345905 on 1 procs for 100 steps with 128 atoms
+Loop time of 0.0344829 on 1 procs for 100 steps with 128 atoms
 
-Performance: 124.890 ns/day, 0.192 hours/ns, 2890.965 timesteps/s, 370.044 katom-step/s
-99.2% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 125.280 ns/day, 0.192 hours/ns, 2899.990 timesteps/s, 371.199 katom-step/s
+99.3% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.03333    | 0.03333    | 0.03333    |   0.0 | 96.36
+Pair    | 0.033254   | 0.033254   | 0.033254   |   0.0 | 96.44
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.00068797 | 0.00068797 | 0.00068797 |   0.0 |  1.99
-Output  | 0.00015217 | 0.00015217 | 0.00015217 |   0.0 |  0.44
-Modify  | 0.00019786 | 0.00019786 | 0.00019786 |   0.0 |  0.57
-Other   |            | 0.0002224  |            |       |  0.64
+Comm    | 0.00069442 | 0.00069442 | 0.00069442 |   0.0 |  2.01
+Output  | 0.0001137  | 0.0001137  | 0.0001137  |   0.0 |  0.33
+Modify  | 0.0002176  | 0.0002176  | 0.0002176  |   0.0 |  0.63
+Other   |            | 0.0002033  |            |       |  0.59
 
 Nlocal:            128 ave         128 max         128 min
 Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.1
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.1
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-337-g6bdf981942-modified)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -41,9 +41,7 @@ mass            1 183.84
 
 pair_style      uf3 2
 pair_coeff      1 1 W_W.uf3
-UF3: W_W.uf3 file should contain UF3 potential for 1 1
-UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacing
+
 
 # # ============= Setup output
 
@@ -88,20 +86,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.113 | 3.113 | 3.113 Mbytes
         80   173.31044     -4.893466       0             -4.8712389     -397601.62    
         90   150.12364     -4.8904922      0             -4.8712388     -397739.2     
        100   128.38807     -4.8877046      0             -4.8712388     -397980.01    
-Loop time of 0.0344829 on 1 procs for 100 steps with 128 atoms
+Loop time of 0.0333361 on 1 procs for 100 steps with 128 atoms
 
-Performance: 125.280 ns/day, 0.192 hours/ns, 2899.990 timesteps/s, 371.199 katom-step/s
-99.3% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 129.589 ns/day, 0.185 hours/ns, 2999.749 timesteps/s, 383.968 katom-step/s
+99.5% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.033254   | 0.033254   | 0.033254   |   0.0 | 96.44
+Pair    | 0.032205   | 0.032205   | 0.032205   |   0.0 | 96.61
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.00069442 | 0.00069442 | 0.00069442 |   0.0 |  2.01
-Output  | 0.0001137  | 0.0001137  | 0.0001137  |   0.0 |  0.33
-Modify  | 0.0002176  | 0.0002176  | 0.0002176  |   0.0 |  0.63
-Other   |            | 0.0002033  |            |       |  0.59
+Comm    | 0.00067389 | 0.00067389 | 0.00067389 |   0.0 |  2.02
+Output  | 9.6021e-05 | 9.6021e-05 | 9.6021e-05 |   0.0 |  0.29
+Modify  | 0.00019596 | 0.00019596 | 0.00019596 |   0.0 |  0.59
+Other   |            | 0.0001652  |            |       |  0.50
 
 Nlocal:            128 ave         128 max         128 min
 Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.4
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.4
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-337-g6bdf981942-modified)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -41,9 +41,7 @@ mass            1 183.84
 
 pair_style      uf3 2
 pair_coeff      1 1 W_W.uf3
-UF3: W_W.uf3 file should contain UF3 potential for 1 1
-UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacing
+
 
 # # ============= Setup output
 
@@ -88,20 +86,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.104 | 3.104 | 3.104 Mbytes
         80   173.31044     -4.893466       0             -4.8712389     -397601.62    
         90   150.12364     -4.8904922      0             -4.8712388     -397739.2     
        100   128.38807     -4.8877046      0             -4.8712388     -397980.01    
-Loop time of 0.00969615 on 4 procs for 100 steps with 128 atoms
+Loop time of 0.0147453 on 4 procs for 100 steps with 128 atoms
 
-Performance: 445.538 ns/day, 0.054 hours/ns, 10313.372 timesteps/s, 1.320 Matom-step/s
-99.7% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 292.975 ns/day, 0.082 hours/ns, 6781.825 timesteps/s, 868.074 katom-step/s
+96.0% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.0075573  | 0.0076696  | 0.007725   |   0.1 | 79.10
+Pair    | 0.0086489  | 0.010103   | 0.0115     |   1.4 | 68.52
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.0017105  | 0.0017634  | 0.0018792  |   0.2 | 18.19
-Output  | 6.7305e-05 | 7.2505e-05 | 8.2576e-05 |   0.0 |  0.75
-Modify  | 4.551e-05  | 4.8142e-05 | 5.4109e-05 |   0.0 |  0.50
-Other   |            | 0.0001425  |            |       |  1.47
+Comm    | 0.0027662  | 0.0041052  | 0.0055079  |   2.1 | 27.84
+Output  | 0.00012555 | 0.0001367  | 0.00015958 |   0.0 |  0.93
+Modify  | 6.4367e-05 | 7.9187e-05 | 9.3374e-05 |   0.0 |  0.54
+Other   |            | 0.000321   |            |       |  2.18
 
 Nlocal:             32 ave          32 max          32 min
 Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.4
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.2b.g++.4
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-326-g338b9b5d61)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -43,9 +43,7 @@ pair_style      uf3 2
 pair_coeff      1 1 W_W.uf3
 UF3: W_W.uf3 file should contain UF3 potential for 1 1
 UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform
-              knot spacing
-
+UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacing
 
 # # ============= Setup output
 
@@ -64,6 +62,7 @@ velocity        all create 300.0 2367804 loop geom
 fix             1 all nve
 run             ${nsteps}
 run             100
+Generated 0 of 0 mixed pair_coeff terms from geometric mixing rule
 Neighbor list info ...
   update: every = 1 steps, delay = 0 steps, check = yes
   max neighbors/atom: 2000, page size: 100000
@@ -89,20 +88,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.104 | 3.104 | 3.104 Mbytes
         80   173.31044     -4.893466       0             -4.8712389     -397601.62    
         90   150.12364     -4.8904922      0             -4.8712388     -397739.2     
        100   128.38807     -4.8877046      0             -4.8712388     -397980.01    
-Loop time of 0.0104225 on 4 procs for 100 steps with 128 atoms
+Loop time of 0.00969615 on 4 procs for 100 steps with 128 atoms
 
-Performance: 414.488 ns/day, 0.058 hours/ns, 9594.626 timesteps/s, 1.228 Matom-step/s
-99.4% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 445.538 ns/day, 0.054 hours/ns, 10313.372 timesteps/s, 1.320 Matom-step/s
+99.7% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.0076422  | 0.0077975  | 0.0081692  |   0.2 | 74.81
+Pair    | 0.0075573  | 0.0076696  | 0.007725   |   0.1 | 79.10
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.001954   | 0.0022765  | 0.0024447  |   0.4 | 21.84
-Output  | 7.7086e-05 | 8.2565e-05 | 9.3188e-05 |   0.0 |  0.79
-Modify  | 4.8524e-05 | 5.011e-05  | 5.1759e-05 |   0.0 |  0.48
-Other   |            | 0.0002159  |            |       |  2.07
+Comm    | 0.0017105  | 0.0017634  | 0.0018792  |   0.2 | 18.19
+Output  | 6.7305e-05 | 7.2505e-05 | 8.2576e-05 |   0.0 |  0.75
+Modify  | 4.551e-05  | 4.8142e-05 | 5.4109e-05 |   0.0 |  0.50
+Other   |            | 0.0001425  |            |       |  1.47
 
 Nlocal:             32 ave          32 max          32 min
 Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.1
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.1
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-326-g338b9b5d61)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -43,13 +43,10 @@ pair_style      uf3 3
 pair_coeff      1 1 W_W.uf3
 UF3: W_W.uf3 file should contain UF3 potential for 1 1
 UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform
-              knot spacing
-pair_coeff      3b 1 1 1 W_W_W.uf3
+UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacingpair_coeff      3b 1 1 1 W_W_W.uf3
 UF3: W_W_W.uf3 file should contain UF3 potential for 1 1 1
 UF3: File W_W_W.uf3 contains 3-body UF3 potential
-UF3: File W_W_W.uf3 contains 3-body UF3 potential with uniform
-            knot spacing
+UF3: File W_W_W.uf3 contains 3-body UF3 potential with uniform knot spacing
 UF3: 3b min cutoff W_W_W.uf3 1-1-1_jk=1.5 1-1-1_jk=1.5
 UF3: 3b min cutoff W_W_W.uf3 1-1-1_ik=1.5 1-1-1_ik=1.5
 UF3: 3b min cutoff W_W_W.uf3 1-1-1_ij=1.5 1-1-1_ij=1.5
@@ -97,20 +94,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.214 | 3.214 | 3.214 Mbytes
         80   53.030322     -4.3599593      0             -4.3531582     -18362.596    
         90   36.611518     -4.3578535      0             -4.3531581     -17898.612    
        100   32.512413     -4.3573279      0             -4.3531581     -17551.048    
-Loop time of 0.478107 on 1 procs for 100 steps with 128 atoms
+Loop time of 0.477708 on 1 procs for 100 steps with 128 atoms
 
-Performance: 9.036 ns/day, 2.656 hours/ns, 209.158 timesteps/s, 26.772 katom-step/s
-99.6% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 9.043 ns/day, 2.654 hours/ns, 209.333 timesteps/s, 26.795 katom-step/s
+99.7% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.47649    | 0.47649    | 0.47649    |   0.0 | 99.66
+Pair    | 0.47636    | 0.47636    | 0.47636    |   0.0 | 99.72
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.00082433 | 0.00082433 | 0.00082433 |   0.0 |  0.17
-Output  | 0.00020504 | 0.00020504 | 0.00020504 |   0.0 |  0.04
-Modify  | 0.00022769 | 0.00022769 | 0.00022769 |   0.0 |  0.05
-Other   |            | 0.0003635  |            |       |  0.08
+Comm    | 0.0007585  | 0.0007585  | 0.0007585  |   0.0 |  0.16
+Output  | 0.00016112 | 0.00016112 | 0.00016112 |   0.0 |  0.03
+Modify  | 0.00019415 | 0.00019415 | 0.00019415 |   0.0 |  0.04
+Other   |            | 0.0002393  |            |       |  0.05
 
 Nlocal:            128 ave         128 max         128 min
 Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.1
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.1
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-337-g6bdf981942-modified)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -41,15 +41,7 @@ mass            1 183.84
 
 pair_style      uf3 3
 pair_coeff      1 1 W_W.uf3
-UF3: W_W.uf3 file should contain UF3 potential for 1 1
-UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacingpair_coeff      3b 1 1 1 W_W_W.uf3
-UF3: W_W_W.uf3 file should contain UF3 potential for 1 1 1
-UF3: File W_W_W.uf3 contains 3-body UF3 potential
-UF3: File W_W_W.uf3 contains 3-body UF3 potential with uniform knot spacing
-UF3: 3b min cutoff W_W_W.uf3 1-1-1_jk=1.5 1-1-1_jk=1.5
-UF3: 3b min cutoff W_W_W.uf3 1-1-1_ik=1.5 1-1-1_ik=1.5
-UF3: 3b min cutoff W_W_W.uf3 1-1-1_ij=1.5 1-1-1_ij=1.5
+pair_coeff      3b 1 1 1 W_W_W.uf3
 
 
 # # ============= Setup output
@@ -94,20 +86,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.214 | 3.214 | 3.214 Mbytes
         80   53.030322     -4.3599593      0             -4.3531582     -18362.596    
         90   36.611518     -4.3578535      0             -4.3531581     -17898.612    
        100   32.512413     -4.3573279      0             -4.3531581     -17551.048    
-Loop time of 0.477708 on 1 procs for 100 steps with 128 atoms
+Loop time of 0.48771 on 1 procs for 100 steps with 128 atoms
 
-Performance: 9.043 ns/day, 2.654 hours/ns, 209.333 timesteps/s, 26.795 katom-step/s
+Performance: 8.858 ns/day, 2.709 hours/ns, 205.040 timesteps/s, 26.245 katom-step/s
 99.7% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.47636    | 0.47636    | 0.47636    |   0.0 | 99.72
+Pair    | 0.48625    | 0.48625    | 0.48625    |   0.0 | 99.70
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.0007585  | 0.0007585  | 0.0007585  |   0.0 |  0.16
-Output  | 0.00016112 | 0.00016112 | 0.00016112 |   0.0 |  0.03
-Modify  | 0.00019415 | 0.00019415 | 0.00019415 |   0.0 |  0.04
-Other   |            | 0.0002393  |            |       |  0.05
+Comm    | 0.00078    | 0.00078    | 0.00078    |   0.0 |  0.16
+Output  | 0.0001819  | 0.0001819  | 0.0001819  |   0.0 |  0.04
+Modify  | 0.00020794 | 0.00020794 | 0.00020794 |   0.0 |  0.04
+Other   |            | 0.0002902  |            |       |  0.06
 
 Nlocal:            128 ave         128 max         128 min
 Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.4
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.4
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-326-g338b9b5d61)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -43,13 +43,10 @@ pair_style      uf3 3
 pair_coeff      1 1 W_W.uf3
 UF3: W_W.uf3 file should contain UF3 potential for 1 1
 UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform
-              knot spacing
-pair_coeff      3b 1 1 1 W_W_W.uf3
+UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacingpair_coeff      3b 1 1 1 W_W_W.uf3
 UF3: W_W_W.uf3 file should contain UF3 potential for 1 1 1
 UF3: File W_W_W.uf3 contains 3-body UF3 potential
-UF3: File W_W_W.uf3 contains 3-body UF3 potential with uniform
-            knot spacing
+UF3: File W_W_W.uf3 contains 3-body UF3 potential with uniform knot spacing
 UF3: 3b min cutoff W_W_W.uf3 1-1-1_jk=1.5 1-1-1_jk=1.5
 UF3: 3b min cutoff W_W_W.uf3 1-1-1_ik=1.5 1-1-1_ik=1.5
 UF3: 3b min cutoff W_W_W.uf3 1-1-1_ij=1.5 1-1-1_ij=1.5
@@ -97,20 +94,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.205 | 3.205 | 3.205 Mbytes
         80   53.030322     -4.3599593      0             -4.3531582     -18362.596    
         90   36.611518     -4.3578535      0             -4.3531581     -17898.612    
        100   32.512413     -4.3573279      0             -4.3531581     -17551.048    
-Loop time of 0.135192 on 4 procs for 100 steps with 128 atoms
+Loop time of 0.130504 on 4 procs for 100 steps with 128 atoms
 
-Performance: 31.955 ns/day, 0.751 hours/ns, 739.688 timesteps/s, 94.680 katom-step/s
-99.5% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 33.102 ns/day, 0.725 hours/ns, 766.258 timesteps/s, 98.081 katom-step/s
+99.1% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.11876    | 0.12259    | 0.13092    |   1.4 | 90.68
+Pair    | 0.1177     | 0.12008    | 0.12246    |   0.7 | 92.01
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.0035898  | 0.011903   | 0.015736   |   4.5 |  8.80
-Output  | 0.00016067 | 0.00018114 | 0.00023041 |   0.0 |  0.13
-Modify  | 9.9574e-05 | 0.00011041 | 0.00012152 |   0.0 |  0.08
-Other   |            | 0.0004092  |            |       |  0.30
+Comm    | 0.0074641  | 0.0098397  | 0.012226   |   2.4 |  7.54
+Output  | 0.00012713 | 0.00013807 | 0.0001675  |   0.0 |  0.11
+Modify  | 8.7486e-05 | 9.3752e-05 | 0.00010061 |   0.0 |  0.07
+Other   |            | 0.0003502  |            |       |  0.27
 
 Nlocal:             32 ave          32 max          32 min
 Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.4
+++ b/examples/PACKAGES/uf3/log.27Mar24.uf3.3b.g++.4
@@ -1,4 +1,4 @@
-LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-331-ga26c281a63)
+LAMMPS (7 Feb 2024 - Development - patch_7Feb2024_update1-337-g6bdf981942-modified)
   using 1 OpenMP thread(s) per MPI task
 # Demonstrate UF3 W potential
 
@@ -41,15 +41,7 @@ mass            1 183.84
 
 pair_style      uf3 3
 pair_coeff      1 1 W_W.uf3
-UF3: W_W.uf3 file should contain UF3 potential for 1 1
-UF3: File W_W.uf3 contains 2-body UF3 potential
-UF3: File W_W.uf3 contains 2-body UF3 potential with uniform knot spacingpair_coeff      3b 1 1 1 W_W_W.uf3
-UF3: W_W_W.uf3 file should contain UF3 potential for 1 1 1
-UF3: File W_W_W.uf3 contains 3-body UF3 potential
-UF3: File W_W_W.uf3 contains 3-body UF3 potential with uniform knot spacing
-UF3: 3b min cutoff W_W_W.uf3 1-1-1_jk=1.5 1-1-1_jk=1.5
-UF3: 3b min cutoff W_W_W.uf3 1-1-1_ik=1.5 1-1-1_ik=1.5
-UF3: 3b min cutoff W_W_W.uf3 1-1-1_ij=1.5 1-1-1_ij=1.5
+pair_coeff      3b 1 1 1 W_W_W.uf3
 
 
 # # ============= Setup output
@@ -94,20 +86,20 @@ Per MPI rank memory allocation (min/avg/max) = 3.205 | 3.205 | 3.205 Mbytes
         80   53.030322     -4.3599593      0             -4.3531582     -18362.596    
         90   36.611518     -4.3578535      0             -4.3531581     -17898.612    
        100   32.512413     -4.3573279      0             -4.3531581     -17551.048    
-Loop time of 0.130504 on 4 procs for 100 steps with 128 atoms
+Loop time of 0.2463 on 4 procs for 100 steps with 128 atoms
 
-Performance: 33.102 ns/day, 0.725 hours/ns, 766.258 timesteps/s, 98.081 katom-step/s
-99.1% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 17.540 ns/day, 1.368 hours/ns, 406.010 timesteps/s, 51.969 katom-step/s
+98.6% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.1177     | 0.12008    | 0.12246    |   0.7 | 92.01
+Pair    | 0.12087    | 0.18077    | 0.24119    |  13.8 | 73.39
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.0074641  | 0.0098397  | 0.012226   |   2.4 |  7.54
-Output  | 0.00012713 | 0.00013807 | 0.0001675  |   0.0 |  0.11
-Modify  | 8.7486e-05 | 9.3752e-05 | 0.00010061 |   0.0 |  0.07
-Other   |            | 0.0003502  |            |       |  0.27
+Comm    | 0.0041617  | 0.064599   | 0.12453    |  23.1 | 26.23
+Output  | 0.00029596 | 0.00031702 | 0.00036352 |   0.0 |  0.13
+Modify  | 0.00012969 | 0.00013491 | 0.00014544 |   0.0 |  0.05
+Other   |            | 0.00048    |            |       |  0.19
 
 Nlocal:             32 ave          32 max          32 min
 Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/src/KOKKOS/pair_uf3_kokkos.cpp
+++ b/src/KOKKOS/pair_uf3_kokkos.cpp
@@ -28,6 +28,7 @@
 #include "kokkos.h"
 #include "kokkos_type.h"
 #include "math_const.h"
+#include "math_special_kokkos.h"
 #include "memory.h"
 #include "memory_kokkos.h"
 #include "neigh_list_kokkos.h"
@@ -35,14 +36,15 @@
 #include "neighbor.h"
 #include "pair_kokkos.h"
 #include "text_file_reader.h"
+
 #include <algorithm>
 #include <cmath>
 #include <utility>
 
-#include <cmath>
-
 using namespace LAMMPS_NS;
 using namespace MathConst;
+using MathSpecialKokkos::cube;
+using MathSpecialKokkos::square;
 
 template <class DeviceType> PairUF3Kokkos<DeviceType>::PairUF3Kokkos(LAMMPS *lmp) : PairUF3(lmp)
 {
@@ -1363,261 +1365,261 @@ std::vector<F_FLOAT> PairUF3Kokkos<DeviceType>::get_constants(double *knots, dou
   std::vector<F_FLOAT> constants(16);
 
   constants[0] = coefficient *
-      (-pow(knots[0], 3) /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+      (-cube(knots[0]) /
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   constants[1] = coefficient *
-      (3 * pow(knots[0], 2) /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+      (3 * square(knots[0]) /
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   constants[2] = coefficient *
       (-3 * knots[0] /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   constants[3] = coefficient *
       (1 /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   constants[4] = coefficient *
-      (pow(knots[1], 2) * knots[4] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+      (square(knots[1]) * knots[4] /
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) +
-       pow(knots[0], 2) * knots[2] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+       square(knots[0]) * knots[2] /
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) +
        knots[0] * knots[1] * knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   constants[5] = coefficient *
-      (-pow(knots[1], 2) /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+      (-square(knots[1]) /
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) -
        2 * knots[1] * knots[4] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) -
-       pow(knots[0], 2) /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+       square(knots[0]) /
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) -
        2 * knots[0] * knots[2] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) -
        knots[0] * knots[1] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) -
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) -
        knots[0] * knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) -
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) -
        knots[1] * knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   constants[6] = coefficient *
       (2 * knots[1] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) +
        knots[4] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) +
        2 * knots[0] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) +
        knots[2] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) +
        knots[0] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) +
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) +
        knots[1] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) +
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) +
        knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   constants[7] = coefficient *
       (-1 /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) -
        1 /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) -
        1 /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   constants[8] = coefficient *
-      (-knots[0] * pow(knots[3], 2) /
+      (-knots[0] * square(knots[3]) /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) -
        knots[1] * knots[3] * knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
-       knots[2] * pow(knots[4], 2) /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
+       knots[2] * square(knots[4]) /
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   constants[9] = coefficient *
       (2 * knots[0] * knots[3] /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
-       pow(knots[3], 2) /
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) +
+       square(knots[3]) /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) +
        knots[1] * knots[3] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
        knots[1] * knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
        knots[3] * knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
        2 * knots[2] * knots[4] /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)) +
-       pow(knots[4], 2) /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])) +
+       square(knots[4]) /
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   constants[10] = coefficient *
       (-knots[0] /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) -
        2 * knots[3] /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) -
        knots[1] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
        knots[3] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
        knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
        knots[2] /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)) -
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])) -
        2 * knots[4] /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   constants[11] = coefficient *
       (1 /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) +
        1 /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
        1 /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   constants[12] = coefficient *
-      (pow(knots[4], 3) /
+      (cube(knots[4]) /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
   constants[13] = coefficient *
-      (-3 * pow(knots[4], 2) /
+      (-3 * square(knots[4]) /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
   constants[14] = coefficient *
       (3 * knots[4] /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
   constants[15] = coefficient *
       (-1 /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
 
   return constants;
 }
@@ -1628,38 +1630,38 @@ std::vector<F_FLOAT> PairUF3Kokkos<DeviceType>::get_dnconstants(double *knots, d
   std::vector<F_FLOAT> constants(9);
 
   constants[0] = coefficient *
-      (pow(knots[0], 2) /
-       (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+      (square(knots[0]) /
+       (square(knots[0]) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
   constants[1] = coefficient *
       (-2 * knots[0] /
-       (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+       (square(knots[0]) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
   constants[2] = coefficient *
-      (1 / (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+      (1 / (square(knots[0]) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
   constants[3] = coefficient *
       (-knots[1] * knots[3] /
-           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
+           (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
        knots[0] * knots[2] /
-           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])));
   constants[4] = coefficient *
       (knots[1] /
-           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
+           (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
        knots[3] /
-           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
+           (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
        knots[0] /
-           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)) +
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])) +
        knots[2] /
-           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])));
   constants[5] = coefficient *
-      (-1 / (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
-       1 / (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+      (-1 / (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
+       1 / (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])));
   constants[6] = coefficient *
-      (pow(knots[3], 2) /
-       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+      (square(knots[3]) /
+       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + square(knots[3])));
   constants[7] = coefficient *
       (-2 * knots[3] /
-       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + square(knots[3])));
   constants[8] = coefficient *
-      (1 / (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+      (1 / (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + square(knots[3])));
 
   return constants;
 }

--- a/src/KOKKOS/pair_uf3_kokkos.cpp
+++ b/src/KOKKOS/pair_uf3_kokkos.cpp
@@ -219,7 +219,7 @@ template <class DeviceType> void PairUF3Kokkos<DeviceType>::create_coefficients(
     }
   }*/
 
-  if (pot_3b){
+  if (pot_3b) {
     for (int i = 1; i < num_of_elements + 1; i++) {
       for (int j = 1; j < num_of_elements + 1; j++) {
         for (int k = 1; k < num_of_elements + 1; k++) {
@@ -851,7 +851,7 @@ template <class DeviceType> void PairUF3Kokkos<DeviceType>::compute(int eflag_in
 
   // loop over neighbor list of my atoms
 
-  if (evflag){
+  if (evflag) {
     Kokkos::parallel_reduce(
         Kokkos::RangePolicy<DeviceType, TagPairUF3ComputeFullA<FULL, 1>>(0, inum), *this, ev);
   }

--- a/src/KOKKOS/pair_uf3_kokkos.cpp
+++ b/src/KOKKOS/pair_uf3_kokkos.cpp
@@ -948,8 +948,6 @@ PairUF3Kokkos<DeviceType>::operator()(TagPairUF3ComputeFullA<NEIGHFLAG, EVFLAG>,
   F_FLOAT fpair = 0;
 
   const int i = d_ilist[ii];
-
-  const tagint itag = tag[i];
   const int itype = type[i];
   const X_FLOAT xtmp = x(i, 0);
   const X_FLOAT ytmp = x(i, 1);
@@ -966,8 +964,6 @@ PairUF3Kokkos<DeviceType>::operator()(TagPairUF3ComputeFullA<NEIGHFLAG, EVFLAG>,
   for (int jj = 0; jj < jnum; jj++) {
     int j = d_neighbors_short(i, jj);
     j &= NEIGHMASK;
-    const tagint jtag = tag[j];
-
     const int jtype = type[j];
 
     const X_FLOAT delx = xtmp - x(j, 0);

--- a/src/KOKKOS/pair_uf3_kokkos.cpp
+++ b/src/KOKKOS/pair_uf3_kokkos.cpp
@@ -207,6 +207,7 @@ template <class DeviceType> double PairUF3Kokkos<DeviceType>::init_one(int i, in
 
 template <class DeviceType> void PairUF3Kokkos<DeviceType>::create_coefficients()
 {
+  const int num_of_elements = atom->ntypes;
   coefficients_created = 1;
 
   /*for (int i = 1; i < num_of_elements + 1; i++) {
@@ -266,6 +267,7 @@ template <class DeviceType> void PairUF3Kokkos<DeviceType>::create_coefficients(
 
 template <class DeviceType> void PairUF3Kokkos<DeviceType>::create_2b_coefficients()
 {
+  const int num_of_elements = atom->ntypes;
 
   // Setup interaction pair map
   //TODO: Instead of using map2b and map3b use simple indexing
@@ -356,6 +358,7 @@ template <class DeviceType> void PairUF3Kokkos<DeviceType>::create_2b_coefficien
 
 template <class DeviceType> void PairUF3Kokkos<DeviceType>::create_3b_coefficients()
 {
+  const int num_of_elements = atom->ntypes;
   // Init interaction map for 3B
 
   Kokkos::realloc(map3b, num_of_elements + 1, num_of_elements + 1, num_of_elements + 1);

--- a/src/ML-UF3/pair_uf3.cpp
+++ b/src/ML-UF3/pair_uf3.cpp
@@ -241,9 +241,10 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
                temp_line);
 
   std::string nbody_on_file = fp2nd_line.next_string();
-  if (utils::strmatch(nbody_on_file, "2B"))
-    utils::logmesg(lmp, "UF3: File {} contains 2-body UF3 potential\n", potf_name);
-  else
+  if (nbody_on_file == "2B") {
+    if (comm->me == 0)
+      utils::logmesg(lmp, "UF3: File {} contains 2-body UF3 potential\n", potf_name);
+  } else
     error->all(FLERR, "UF3: Expected a 2B UF3 file but found {}", nbody_on_file);
 
   int leading_trim = fp2nd_line.next_int();
@@ -258,25 +259,23 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
                "trailing_trim=3");
 
   std::string knot_type = fp2nd_line.next_string();
-  if (utils::strmatch(knot_type, "uk")) {
-    utils::logmesg(lmp,
-                   "UF3: File {} contains 2-body UF3 potential with uniform "
-                   "knot spacing",
-                   potf_name);
+  if (knot_type == "uk") {
+    if (comm->me == 0)
+      utils::logmesg(lmp,
+                     "UF3: File {} contains 2-body UF3 potential with uniform knot spacing",
+                     potf_name);
     knot_spacing_type_2b[itype][jtype] = 0;
     knot_spacing_type_2b[jtype][itype] = 0;
-  } else if (utils::strmatch(knot_type, "nk")) {
-    utils::logmesg(lmp,
-                   "UF3: File {} contains 2-body UF3 potential with non-uniform "
-                   "knot spacing",
-                   potf_name);
+  } else if (knot_type == "nk") {
+    if (comm->me == 0)
+      utils::logmesg(lmp,
+                     "UF3: File {} contains 2-body UF3 potential with non-uniform knot spacing",
+                     potf_name);
     knot_spacing_type_2b[itype][jtype] = 1;
     knot_spacing_type_2b[jtype][itype] = 1;
-    /*error->all(FLERR, "UF3: Current implementation only works with uniform "
-            " knot spacing");*/
   } else
     error->all(FLERR,
-               "UF3: Expected either 'uk'(uniform-knots) or 'nk'(non-uniform knots) "
+               "UF3: Expected either 'uk'(uniform-knots) or 'nk'(non-uniform knots). "
                "Found {} on the 2nd line of {} pot file",
                knot_type, potf_name);
 
@@ -337,8 +336,9 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
 
 void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name)
 {
-  utils::logmesg(lmp, "UF3: {} file should contain UF3 potential for {} {} {}\n", potf_name, itype,
-                 jtype, ktype);
+  if (comm->me == 0)
+    utils::logmesg(lmp, "UF3: {} file should contain UF3 potential for {} {} {}\n",
+                   potf_name, itype, jtype, ktype);
 
   FILE *fp = utils::open_potential(potf_name, lmp, nullptr);
   if (!fp)
@@ -374,35 +374,32 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
 
   std::string nbody_on_file = fp2nd_line.next_string();
 
-  if (utils::strmatch(nbody_on_file, "3B"))
-    utils::logmesg(lmp, "UF3: File {} contains 3-body UF3 potential\n", potf_name);
-  else
+  if (nbody_on_file == "3B") {
+    if (comm->me == 0)
+      utils::logmesg(lmp, "UF3: File {} contains 3-body UF3 potential\n", potf_name);
+  } else
     error->all(FLERR, "UF3: Expected a 3B UF3 file but found {}", nbody_on_file);
 
   int leading_trim = fp2nd_line.next_int();
   int trailing_trim = fp2nd_line.next_int();
   if (leading_trim != 0)
-    error->all(FLERR,
-               "UF3: Current implementation is throughly tested only for "
-               "leading_trim=0\n");
+    error->all(FLERR, "UF3: Current implementation is throughly tested only for leading_trim=0");
   if (trailing_trim != 3)
-    error->all(FLERR,
-               "UF3: Current implementation is throughly tested only for "
-               "trailing_trim=3\n");
+    error->all(FLERR, "UF3: Current implementation is throughly tested only for trailing_trim=3");
 
   std::string knot_type = fp2nd_line.next_string();
-  if (utils::strmatch(knot_type, "uk")) {
-    utils::logmesg(lmp,
-                   "UF3: File {} contains 3-body UF3 potential with uniform "
-                   "knot spacing\n",
-                   potf_name);
+  if (knot_type == "uk") {
+    if (comm->me == 0)
+      utils::logmesg(lmp,
+                     "UF3: File {} contains 3-body UF3 potential with uniform knot spacing\n",
+                     potf_name);
     knot_spacing_type_3b[itype][jtype][ktype] = 0;
     knot_spacing_type_3b[itype][ktype][jtype] = 0;
-  } else if (utils::strmatch(knot_type, "nk")) {
-    utils::logmesg(lmp,
-                   "UF3: File {} contains 3-body UF3 potential with non-uniform "
-                   "knot spacing\n",
-                   potf_name);
+  } else if (knot_type == "nk") {
+    if (comm->me == 0)
+      utils::logmesg(lmp,
+                     "UF3: File {} contains 3-body UF3 potential with non-uniform knot spacing\n",
+                     potf_name);
     knot_spacing_type_3b[itype][jtype][ktype] = 1;
     knot_spacing_type_3b[itype][ktype][jtype] = 1;
   } else
@@ -628,7 +625,6 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
 
     //cut is used in init_one which is called by pair.cpp at line 267 where the return of init_one is squared
     cut[temp_type1][temp_type2] = fp3rd_line.next_double();
-    // if(comm->me==0) utils::logmesg(lmp,"UF3: Cutoff {}\n",cutsq[temp_type1][temp_type2]);
     cut[temp_type2][temp_type1] = cut[temp_type1][temp_type2];
 
     int temp_line_len = fp3rd_line.next_int();
@@ -649,18 +645,14 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
     temp_line_len = fp5th_line.next_int();
 
     temp_line = txtfilereader.next_line(temp_line_len);
-    // utils::logmesg(lmp,"UF3:11 {}",temp_line);
     ValueTokenizer fp6th_line(temp_line);
-    // if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",temp_line_len);
     n2b_coeff[temp_type1][temp_type2].resize(temp_line_len);
     n2b_coeff[temp_type2][temp_type1].resize(temp_line_len);
 
     for (int k = 0; k < temp_line_len; k++) {
       n2b_coeff[temp_type1][temp_type2][k] = fp6th_line.next_double();
       n2b_coeff[temp_type2][temp_type1][k] = n2b_coeff[temp_type1][temp_type2][k];
-      // if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",n2b_coeff[temp_type1][temp_type2][k]);
     }
-    // for(int i=0;i<n2b_coeff[temp_type1][temp_type2].size();i++) if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",n2b_coeff[temp_type1][temp_type2][i]);
     if (n2b_knot[temp_type1][temp_type2].size() != n2b_coeff[temp_type1][temp_type2].size() + 4) {
       error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",
                  potf_name);

--- a/src/ML-UF3/pair_uf3.cpp
+++ b/src/ML-UF3/pair_uf3.cpp
@@ -40,7 +40,9 @@ using MathConst::THIRD;
 
 /* ---------------------------------------------------------------------- */
 
-PairUF3::PairUF3(LAMMPS *lmp) : Pair(lmp)
+PairUF3::PairUF3(LAMMPS *lmp) :
+    Pair(lmp), setflag_3b(nullptr), knot_spacing_type_2b(nullptr), knot_spacing_type_3b(nullptr),
+    cut(nullptr), cut_3b(nullptr), cut_3b_list(nullptr), min_cut_3b(nullptr)
 {
   single_enable = 1;    // 1 if single() routine exists
   restartinfo = 0;      // 1 if pair style writes restart info
@@ -60,6 +62,7 @@ PairUF3::~PairUF3()
     memory->destroy(setflag);
     memory->destroy(cutsq);
     memory->destroy(cut);
+    memory->destroy(knot_spacing_type_2b);
 
     if (pot_3b) {
       memory->destroy(setflag_3b);
@@ -67,6 +70,7 @@ PairUF3::~PairUF3()
       memory->destroy(cut_3b_list);
       memory->destroy(min_cut_3b);
       memory->destroy(neighshort);
+      memory->destroy(knot_spacing_type_3b);
     }
   }
 }

--- a/src/ML-UF3/pair_uf3.cpp
+++ b/src/ML-UF3/pair_uf3.cpp
@@ -83,7 +83,7 @@ void PairUF3::settings(int narg, char **arg)
                "Invalid number of arguments for pair_style uf3"
                "  Are you using a 2-body or 2 & 3-body UF potential?");
   nbody_flag = utils::numeric(FLERR, arg[0], true, lmp);
-  num_of_elements = atom->ntypes;
+  const int num_of_elements = atom->ntypes;
   if (nbody_flag == 2) {
     pot_3b = false;
     manybody_flag = 0;
@@ -133,6 +133,7 @@ void PairUF3::coeff(int narg, char **arg)
 void PairUF3::allocate()
 {
   allocated = 1;
+  const int num_of_elements = atom->ntypes;
 
   // Contains info about wether UF potential were found for type i and j
   memory->create(setflag, num_of_elements + 1, num_of_elements + 1, "pair:setflag");
@@ -842,6 +843,7 @@ double PairUF3::init_one(int i /*i*/, int /*j*/ j)
 
 void PairUF3::create_bsplines()
 {
+  const int num_of_elements = atom->ntypes;
   bsplines_created = 1;
   for (int i = 1; i < num_of_elements + 1; i++) {
     for (int j = 1; j < num_of_elements + 1; j++) {
@@ -1169,9 +1171,8 @@ double PairUF3::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
 
 double PairUF3::memory_usage()
 {
+  const int num_of_elements = atom->ntypes;
   double bytes = Pair::memory_usage();
-
-  bytes = 0;
 
   bytes += (double) 5 * sizeof(double);    //num_of_elements, nbody_flag,
                                            //n2body_pot_files, n3body_pot_files,

--- a/src/ML-UF3/pair_uf3.cpp
+++ b/src/ML-UF3/pair_uf3.cpp
@@ -209,10 +209,6 @@ void PairUF3::allocate()
 
 void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
 {
-  if (comm->me == 0)
-    utils::logmesg(lmp, "UF3: {} file should contain UF3 potential for {} {}\n", potf_name, itype,
-                   jtype);
-
   FILE *fp = utils::open_potential(potf_name, lmp, nullptr);
   if (!fp)
     error->all(FLERR, "Cannot open UF3 potential file {}: {}", potf_name, utils::getsyserror());
@@ -246,10 +242,7 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
                temp_line);
 
   std::string nbody_on_file = fp2nd_line.next_string();
-  if (nbody_on_file == "2B") {
-    if (comm->me == 0)
-      utils::logmesg(lmp, "UF3: File {} contains 2-body UF3 potential\n", potf_name);
-  } else
+  if (nbody_on_file != "2B")
     error->all(FLERR, "UF3: Expected a 2B UF3 file but found {}", nbody_on_file);
 
   int leading_trim = fp2nd_line.next_int();
@@ -265,17 +258,9 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
 
   std::string knot_type = fp2nd_line.next_string();
   if (knot_type == "uk") {
-    if (comm->me == 0)
-      utils::logmesg(lmp,
-                     "UF3: File {} contains 2-body UF3 potential with uniform knot spacing",
-                     potf_name);
     knot_spacing_type_2b[itype][jtype] = 0;
     knot_spacing_type_2b[jtype][itype] = 0;
   } else if (knot_type == "nk") {
-    if (comm->me == 0)
-      utils::logmesg(lmp,
-                     "UF3: File {} contains 2-body UF3 potential with non-uniform knot spacing",
-                     potf_name);
     knot_spacing_type_2b[itype][jtype] = 1;
     knot_spacing_type_2b[jtype][itype] = 1;
   } else
@@ -341,10 +326,6 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
 
 void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name)
 {
-  if (comm->me == 0)
-    utils::logmesg(lmp, "UF3: {} file should contain UF3 potential for {} {} {}\n",
-                   potf_name, itype, jtype, ktype);
-
   FILE *fp = utils::open_potential(potf_name, lmp, nullptr);
   if (!fp)
     error->all(FLERR, "Cannot open UF3 potential file {}: {}", potf_name, utils::getsyserror());
@@ -378,11 +359,7 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
                temp_line);
 
   std::string nbody_on_file = fp2nd_line.next_string();
-
-  if (nbody_on_file == "3B") {
-    if (comm->me == 0)
-      utils::logmesg(lmp, "UF3: File {} contains 3-body UF3 potential\n", potf_name);
-  } else
+  if (nbody_on_file != "3B")
     error->all(FLERR, "UF3: Expected a 3B UF3 file but found {}", nbody_on_file);
 
   int leading_trim = fp2nd_line.next_int();
@@ -394,17 +371,9 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
 
   std::string knot_type = fp2nd_line.next_string();
   if (knot_type == "uk") {
-    if (comm->me == 0)
-      utils::logmesg(lmp,
-                     "UF3: File {} contains 3-body UF3 potential with uniform knot spacing\n",
-                     potf_name);
     knot_spacing_type_3b[itype][jtype][ktype] = 0;
     knot_spacing_type_3b[itype][ktype][jtype] = 0;
   } else if (knot_type == "nk") {
-    if (comm->me == 0)
-      utils::logmesg(lmp,
-                     "UF3: File {} contains 3-body UF3 potential with non-uniform knot spacing\n",
-                     potf_name);
     knot_spacing_type_3b[itype][jtype][ktype] = 1;
     knot_spacing_type_3b[itype][ktype][jtype] = 1;
   } else
@@ -463,13 +432,7 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
   }
 
   min_cut_3b[itype][jtype][ktype][0] = n3b_knot_matrix[itype][jtype][ktype][0][0];
-  //min_cut_3b[itype][jtype][ktype][0] --> cutoff for jk distance
-
   min_cut_3b[itype][ktype][jtype][0] = n3b_knot_matrix[itype][ktype][jtype][0][0];
-  if (comm->me == 0)
-    utils::logmesg(lmp, "UF3: 3b min cutoff {} {}-{}-{}_jk={} {}-{}-{}_jk={}\n", potf_name, itype,
-                   jtype, ktype, min_cut_3b[itype][jtype][ktype][0], itype, ktype, jtype,
-                   min_cut_3b[itype][ktype][jtype][0]);
 
   int num_knots_3b_ik = fp3rd_line.next_int();
   temp_line = txtfilereader.next_line(num_knots_3b_ik);
@@ -487,13 +450,7 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
   }
 
   min_cut_3b[itype][jtype][ktype][1] = n3b_knot_matrix[itype][jtype][ktype][1][0];
-  //min_cut_3b[itype][jtype][ktype][1] --> cutoff for ik distance
-
   min_cut_3b[itype][ktype][jtype][2] = n3b_knot_matrix[itype][ktype][jtype][2][0];
-  if (comm->me == 0)
-    utils::logmesg(lmp, "UF3: 3b min cutoff {} {}-{}-{}_ik={} {}-{}-{}_ik={}\n", potf_name, itype,
-                   jtype, ktype, min_cut_3b[itype][jtype][ktype][1], itype, ktype, jtype,
-                   min_cut_3b[itype][ktype][jtype][2]);
 
   int num_knots_3b_ij = fp3rd_line.next_int();
   temp_line = txtfilereader.next_line(num_knots_3b_ij);
@@ -511,12 +468,7 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
   }
 
   min_cut_3b[itype][jtype][ktype][2] = n3b_knot_matrix[itype][jtype][ktype][2][0];
-  //min_cut_3b[itype][jtype][ktype][2] --> cutoff for ij distance
   min_cut_3b[itype][ktype][jtype][1] = n3b_knot_matrix[itype][ktype][jtype][1][0];
-  if (comm->me == 0)
-    utils::logmesg(lmp, "UF3: 3b min cutoff {} {}-{}-{}_ij={} {}-{}-{}_ij={}\n", potf_name, itype,
-                   jtype, ktype, min_cut_3b[itype][jtype][ktype][2], itype, ktype, jtype,
-                   min_cut_3b[itype][ktype][jtype][1]);
 
   temp_line = txtfilereader.next_line(3);
   ValueTokenizer fp7th_line(temp_line);
@@ -597,8 +549,6 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
 
 void PairUF3::uf3_read_pot_file(char *potf_name)
 {
-  if (comm->me == 0) utils::logmesg(lmp, "\nUF3: Opening {} file\n", potf_name);
-
   FILE *fp = utils::open_potential(potf_name, lmp, nullptr);
   if (!fp)
     error->all(FLERR, "Cannot open UF3 potential file {}: {}", potf_name, utils::getsyserror());
@@ -613,10 +563,6 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
     error->all(FLERR, "UF3: {} file is not UF3 POT type, found type {} {} on the file", potf_name,
                fp1st_line.next(), fp1st_line.next());
 
-  if (comm->me == 0)
-    utils::logmesg(lmp, "UF3: {} file is of type {} {}\n", potf_name, fp1st_line.next(),
-                   fp1st_line.next());
-
   temp_line = txtfilereader.next_line(1);
   Tokenizer fp2nd_line(temp_line);
   if (fp2nd_line.contains("2B") == 1) {
@@ -624,9 +570,6 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
     ValueTokenizer fp3rd_line(temp_line);
     int temp_type1 = fp3rd_line.next_int();
     int temp_type2 = fp3rd_line.next_int();
-    if (comm->me == 0)
-      utils::logmesg(lmp, "UF3: {} file contains 2-body UF3 potential for {} {}\n", potf_name,
-                     temp_type1, temp_type2);
 
     //cut is used in init_one which is called by pair.cpp at line 267 where the return of init_one is squared
     cut[temp_type1][temp_type2] = fp3rd_line.next_double();
@@ -670,9 +613,6 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
     int temp_type1 = fp3rd_line.next_int();
     int temp_type2 = fp3rd_line.next_int();
     int temp_type3 = fp3rd_line.next_int();
-    if (comm->me == 0)
-      utils::logmesg(lmp, "UF3: {} file contains 3-body UF3 potential for {} {} {}\n", potf_name,
-                     temp_type1, temp_type2, temp_type3);
 
     double cut3b_rjk = fp3rd_line.next_double();
     double cut3b_rij = fp3rd_line.next_double();
@@ -712,11 +652,6 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
         n3b_knot_matrix[temp_type1][temp_type2][temp_type3][0][0];
     min_cut_3b[temp_type1][temp_type3][temp_type2][0] =
         n3b_knot_matrix[temp_type1][temp_type3][temp_type2][0][0];
-    if (comm->me == 0)
-      utils::logmesg(lmp, "UF3: 3b min cutoff {} {}-{}-{}_0={} {}-{}-{}_0={}\n", potf_name,
-                     temp_type1, temp_type2, temp_type3,
-                     min_cut_3b[temp_type1][temp_type2][temp_type3][0], temp_type1, temp_type3,
-                     temp_type2, min_cut_3b[temp_type1][temp_type3][temp_type2][0]);
 
     temp_line_len = fp3rd_line.next_int();
     temp_line = txtfilereader.next_line(temp_line_len);
@@ -733,11 +668,6 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
         n3b_knot_matrix[temp_type1][temp_type2][temp_type3][1][0];
     min_cut_3b[temp_type1][temp_type3][temp_type2][2] =
         n3b_knot_matrix[temp_type1][temp_type3][temp_type2][2][0];
-    if (comm->me == 0)
-      utils::logmesg(lmp, "UF3: 3b min cutoff {} {}-{}-{}_1={} {}-{}-{}_2={}\n", potf_name,
-                     temp_type1, temp_type2, temp_type3,
-                     min_cut_3b[temp_type1][temp_type2][temp_type3][1], temp_type1, temp_type3,
-                     temp_type2, min_cut_3b[temp_type1][temp_type3][temp_type2][2]);
 
     temp_line_len = fp3rd_line.next_int();
     temp_line = txtfilereader.next_line(temp_line_len);
@@ -754,11 +684,6 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
         n3b_knot_matrix[temp_type1][temp_type2][temp_type3][2][0];
     min_cut_3b[temp_type1][temp_type3][temp_type2][1] =
         n3b_knot_matrix[temp_type1][temp_type3][temp_type2][1][0];
-    if (comm->me == 0)
-      utils::logmesg(lmp, "UF3: 3b min cutoff {} {}-{}-{}_2={} {}-{}-{}_1={}\n", potf_name,
-                     temp_type1, temp_type2, temp_type3,
-                     min_cut_3b[temp_type1][temp_type2][temp_type3][2], temp_type1, temp_type3,
-                     temp_type2, min_cut_3b[temp_type1][temp_type3][temp_type2][2]);
 
     temp_line = txtfilereader.next_line(3);
     ValueTokenizer fp7th_line(temp_line);

--- a/src/ML-UF3/pair_uf3.cpp
+++ b/src/ML-UF3/pair_uf3.cpp
@@ -212,7 +212,8 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, char *potf_name)
     utils::logmesg(lmp, "UF3: {} file should contain UF3 potential for {} {}\n", potf_name, itype, jtype);
 
   FILE *fp = utils::open_potential(potf_name, lmp, nullptr);
-  if (!fp) error->one(FLERR,"Cannot open UF3 potential file {}", potf_name);
+  if (!fp)
+    error->all(FLERR, "Cannot open UF3 potential file {}: {}", potf_name, utils::getsyserror());
 
   TextFileReader txtfilereader(fp, "UF3:POTFP");
   txtfilereader.ignore_comments = false;
@@ -329,7 +330,8 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
           potf_name, itype, jtype, ktype);
 
   FILE *fp = utils::open_potential(potf_name, lmp, nullptr);
-  if (!fp) error->one(FLERR,"Cannot open UF3 potential file {}", potf_name);
+  if (!fp)
+    error->all(FLERR, "Cannot open UF3 potential file {}: {}", potf_name, utils::getsyserror());
 
   TextFileReader txtfilereader(fp, "UF3:POTFP");
   txtfilereader.ignore_comments = false;
@@ -559,7 +561,6 @@ void PairUF3::uf3_read_pot_file(int itype, int jtype, int ktype, char *potf_name
 
   setflag_3b[itype][jtype][ktype] = 1;
   setflag_3b[itype][ktype][jtype] = 1;
-
 }
 
 void PairUF3::uf3_read_pot_file(char *potf_name)
@@ -567,7 +568,8 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
   if (comm->me == 0) utils::logmesg(lmp, "\nUF3: Opening {} file\n", potf_name);
 
   FILE *fp = utils::open_potential(potf_name, lmp, nullptr);
-  if (!fp) error->all(FLERR,"Cannot open UF3 potential file {}",potf_name);
+  if (!fp)
+    error->all(FLERR, "Cannot open UF3 potential file {}: {}", potf_name, utils::getsyserror());
 
   TextFileReader txtfilereader(fp, "UF3:POTFP");
   txtfilereader.ignore_comments = false;

--- a/src/ML-UF3/pair_uf3.h
+++ b/src/ML-UF3/pair_uf3.h
@@ -53,7 +53,7 @@ class PairUF3 : public Pair {
   void uf3_read_pot_file(char *potf_name);
   void uf3_read_pot_file(int i, int j, char *potf_name);
   void uf3_read_pot_file(int i, int j, int k, char *potf_name);
-  int num_of_elements, nbody_flag, n2body_pot_files, n3body_pot_files, tot_pot_files;
+  int nbody_flag, n2body_pot_files, n3body_pot_files, tot_pot_files;
   int bsplines_created;
   int coeff_matrix_dim1, coeff_matrix_dim2, coeff_matrix_dim3, coeff_matrix_elements_len;
   bool pot_3b;

--- a/src/ML-UF3/uf3_bspline_basis2.cpp
+++ b/src/ML-UF3/uf3_bspline_basis2.cpp
@@ -14,10 +14,10 @@
 
 #include "uf3_bspline_basis2.h"
 
-#include "utils.h"
-#include <vector>
+#include "math_special.h"
 
 using namespace LAMMPS_NS;
+using MathSpecial::square;
 
 // Constructor
 // Initializes coefficients and knots
@@ -28,45 +28,45 @@ uf3_bspline_basis2::uf3_bspline_basis2(LAMMPS *ulmp, const double *knots, double
 
   double c0, c1, c2;
 
-  c0 = coefficient *
-      (pow(knots[0], 2) /
-       (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+  c0 = coefficient
+    * (square(knots[0])
+       / (square(knots[0]) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
   c1 = coefficient *
-      (-2 * knots[0] /
-       (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+      (-2.0 * knots[0] /
+       (square(knots[0]) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
   c2 = coefficient *
-      (1 / (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+      (1.0 / (square(knots[0]) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
   constants.push_back(c0);
   constants.push_back(c1);
   constants.push_back(c2);
   c0 = coefficient *
       (-knots[1] * knots[3] /
-           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
+           (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
        knots[0] * knots[2] /
-           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])));
   c1 = coefficient *
       (knots[1] /
-           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
+           (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
        knots[3] /
-           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
+           (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
        knots[0] /
-           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)) +
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])) +
        knots[2] /
-           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])));
   c2 = coefficient *
-      (-1 / (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
-       1 / (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+      (-1.0 / (square(knots[1]) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
+       1.0 / (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + square(knots[2])));
   constants.push_back(c0);
   constants.push_back(c1);
   constants.push_back(c2);
   c0 = coefficient *
-      (pow(knots[3], 2) /
-       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+      (square(knots[3]) /
+       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + square(knots[3])));
   c1 = coefficient *
-      (-2 * knots[3] /
-       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+      (-2.0 * knots[3] /
+       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + square(knots[3])));
   c2 = coefficient *
-      (1 / (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+      (1.0 / (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + square(knots[3])));
   constants.push_back(c0);
   constants.push_back(c1);
   constants.push_back(c2);

--- a/src/ML-UF3/uf3_bspline_basis3.cpp
+++ b/src/ML-UF3/uf3_bspline_basis3.cpp
@@ -14,10 +14,11 @@
 
 #include "uf3_bspline_basis3.h"
 
-#include "utils.h"
-#include <vector>
+#include "math_special.h"
 
 using namespace LAMMPS_NS;
+using MathSpecial::cube;
+using MathSpecial::square;
 
 // Constructor
 // Initializes coefficients and knots
@@ -29,27 +30,27 @@ uf3_bspline_basis3::uf3_bspline_basis3(LAMMPS *ulmp, const double *knots, double
   double c0, c1, c2, c3;
 
   c0 = coefficient *
-      (-pow(knots[0], 3) /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+      (-cube(knots[0]) /
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   c1 = coefficient *
-      (3 * pow(knots[0], 2) /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+      (3.0 * square(knots[0]) /
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   c2 = coefficient *
-      (-3 * knots[0] /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+      (-3.0 * knots[0] /
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   c3 = coefficient *
-      (1 /
-       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
-        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+      (1.0 /
+       (-cube(knots[0]) + square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
+        square(knots[0]) * knots[3] - knots[0] * knots[1] * knots[2] -
         knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
         knots[1] * knots[2] * knots[3]));
   constants.push_back(c0);
@@ -57,245 +58,245 @@ uf3_bspline_basis3::uf3_bspline_basis3(LAMMPS *ulmp, const double *knots, double
   constants.push_back(c2);
   constants.push_back(c3);
   c0 = coefficient *
-      (pow(knots[1], 2) * knots[4] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+      (square(knots[1]) * knots[4] /
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) +
-       pow(knots[0], 2) * knots[2] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+       square(knots[0]) * knots[2] /
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) +
        knots[0] * knots[1] * knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   c1 = coefficient *
-      (-pow(knots[1], 2) /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+      (-square(knots[1]) /
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) -
-       2 * knots[1] * knots[4] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+       2.0 * knots[1] * knots[4] /
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) -
-       pow(knots[0], 2) /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+       square(knots[0]) /
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
-       2 * knots[0] * knots[2] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) -
+       2.0 * knots[0] * knots[2] /
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) -
        knots[0] * knots[1] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) -
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) -
        knots[0] * knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) -
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) -
        knots[1] * knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   c2 = coefficient *
-      (2 * knots[1] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+      (2.0 * knots[1] /
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) +
        knots[4] /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) +
-       2 * knots[0] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+       2.0 * knots[0] /
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) +
        knots[2] /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) +
        knots[0] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) +
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) +
        knots[1] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) +
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])) +
        knots[3] /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   c3 = coefficient *
-      (-1 /
-           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
-            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+      (-1.0 /
+           (-cube(knots[1]) + square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
+            square(knots[1]) * knots[4] - knots[1] * knots[2] * knots[3] -
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
             knots[2] * knots[3] * knots[4]) -
-       1 /
-           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+       1.0 /
+           (-square(knots[0]) * knots[1] + square(knots[0]) * knots[2] +
             knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
-            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
-            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
-       1 /
-           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * square(knots[2]) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + square(knots[2]) * knots[3]) -
+       1.0 /
+           (-knots[0] * square(knots[1]) + knots[0] * knots[1] * knots[2] +
             knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
-            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
-            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+            square(knots[1]) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * square(knots[3]) + knots[2] * square(knots[3])));
   constants.push_back(c0);
   constants.push_back(c1);
   constants.push_back(c2);
   constants.push_back(c3);
   c0 = coefficient *
-      (-knots[0] * pow(knots[3], 2) /
+      (-knots[0] * square(knots[3]) /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) -
        knots[1] * knots[3] * knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
-       knots[2] * pow(knots[4], 2) /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
+       knots[2] * square(knots[4]) /
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   c1 = coefficient *
-      (2 * knots[0] * knots[3] /
+      (2.0 * knots[0] * knots[3] /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
-       pow(knots[3], 2) /
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) +
+       square(knots[3]) /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) +
        knots[1] * knots[3] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
        knots[1] * knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
        knots[3] * knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
-       2 * knots[2] * knots[4] /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
+       2.0 * knots[2] * knots[4] /
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)) +
-       pow(knots[4], 2) /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])) +
+       square(knots[4]) /
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   c2 = coefficient *
       (-knots[0] /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
-       2 * knots[3] /
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) -
+       2.0 * knots[3] /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) -
        knots[1] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
        knots[3] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
        knots[4] /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) -
        knots[2] /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)) -
-       2 * knots[4] /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])) -
+       2.0 * knots[4] /
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   c3 = coefficient *
-      (1 /
+      (1.0 /
            (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
-            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
-            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
-            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
-       1 /
-           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[0] * knots[2] * knots[3] - knots[0] * square(knots[3]) +
+            knots[1] * knots[2] * knots[3] - knots[1] * square(knots[3]) -
+            knots[2] * square(knots[3]) + cube(knots[3])) +
+       1.0 /
+           (-square(knots[1]) * knots[2] + square(knots[1]) * knots[3] +
             knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
-            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
-            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
-       1 /
-           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * square(knots[3]) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + square(knots[3]) * knots[4]) +
+       1.0 /
+           (-knots[1] * square(knots[2]) + knots[1] * knots[2] * knots[3] +
             knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
-            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
-            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+            square(knots[2]) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * square(knots[4]) + knots[3] * square(knots[4])));
   constants.push_back(c0);
   constants.push_back(c1);
   constants.push_back(c2);
   constants.push_back(c3);
   c0 = coefficient *
-      (pow(knots[4], 3) /
+      (cube(knots[4]) /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
   c1 = coefficient *
-      (-3 * pow(knots[4], 2) /
+      (-3.0 * square(knots[4]) /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
   c2 = coefficient *
-      (3 * knots[4] /
+      (3.0 * knots[4] /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
   c3 = coefficient *
-      (-1 /
+      (-1.0 /
        (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
-        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
-        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
-        pow(knots[4], 3)));
+        knots[1] * knots[3] * knots[4] - knots[1] * square(knots[4]) +
+        knots[2] * knots[3] * knots[4] - knots[2] * square(knots[4]) - knots[3] * square(knots[4]) +
+        cube(knots[4])));
   constants.push_back(c0);
   constants.push_back(c1);
   constants.push_back(c2);

--- a/src/ML-UF3/uf3_triplet_bspline.cpp
+++ b/src/ML-UF3/uf3_triplet_bspline.cpp
@@ -13,7 +13,7 @@
 
 #include "uf3_triplet_bspline.h"
 #include "error.h"
-#include <iostream>
+
 #include <vector>
 
 using namespace LAMMPS_NS;
@@ -306,6 +306,7 @@ int uf3_triplet_bspline::get_starting_index_nonuniform(const std::vector<double>
       }
     }
   }
+  return -1;
 }
 
 double uf3_triplet_bspline::memory_usage()


### PR DESCRIPTION
Improvements in this pull request:
- close opened files when reading the potential files to avoid leaking file descriptors
- apply clang-format
- consistently use error->all() when failing on all MPI ranks
- remove log messages from reading potential
- use C++ style string comparisons instead of utils::strmatch() where exact match is required
- replace pow(x,2) with faster and more accurate MathSpecial::square(), same for pow(x,3) and MathSpecia::cube()
